### PR TITLE
Duplicate fields throw an error

### DIFF
--- a/src/FacebookPageFeed.php
+++ b/src/FacebookPageFeed.php
@@ -64,7 +64,7 @@ class FacebookPageFeed extends AbstractFeedProvider
         $this->cacheKey = $this->getFeedPlatform() . $this->pageId;
 
         $this->fields = ['link','picture','message','story','type','created_time','source','status_type'];
-        $this->fields = array_merge($this->fields, $fields);
+        $this->fields = array_unique(array_merge($this->fields, $fields));
 
         if (null === $this->accessToken ||
             false === $this->accessToken ||


### PR DESCRIPTION
Avoid problems  by using array_unique() on $fields parameter.
